### PR TITLE
Community taskcluster migration

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -23,8 +23,8 @@ tasks:
       - taskId: {$eval: as_slugid("lint_task")}
         created: {$fromNow: ''}
         deadline: {$fromNow: '1 hour'}
-        provisionerId: aws-provisioner-v1
-        workerType: github-worker
+        provisionerId: proj-taskcluster_yml_validator
+        workerType: ci
         payload:
           maxRunTime: 3600
           image: python
@@ -45,8 +45,8 @@ tasks:
       - taskId: {$eval: as_slugid("tests_task")}
         created: {$fromNow: ''}
         deadline: {$fromNow: '1 hour'}
-        provisionerId: aws-provisioner-v1
-        workerType: github-worker
+        provisionerId: proj-taskcluster_yml_validator
+        workerType: ci
         payload:
           maxRunTime: 3600
           image: python

--- a/taskcluster_yml_validator/__init__.py
+++ b/taskcluster_yml_validator/__init__.py
@@ -16,19 +16,19 @@ from taskcluster_yml_validator.events import pull_request_open, push, tag_push
 
 def validate(path):
     r = requests.get(
-        "https://schemas.taskcluster.net/github/v1/taskcluster-github-config.v1.json"
+        "https://community-tc.services.mozilla.com/schemas/github/v1/taskcluster-github-config.v1.json"
     )
     r.raise_for_status()
     taskcluster_yml_schema = r.json()
 
     r = requests.get(
-        "https://schemas.taskcluster.net/queue/v1/create-task-request.json"
+        "https://community-tc.services.mozilla.com/schemas/queue/v1/create-task-request.json"
     )
     r.raise_for_status()
     task_schema = r.json()
 
     # TODO: Don't assume docker-worker!
-    r = requests.get("https://schemas.taskcluster.net/docker-worker/v1/payload.json")
+    r = requests.get("https://raw.githubusercontent.com/taskcluster/docker-worker/master/schemas/v1/payload.json")
     r.raise_for_status()
     payload_schema = r.json()
 


### PR DESCRIPTION
Hi!

I work on the Taskcluster team at Mozilla, and I'm writing to let you know about an upcoming change to our deployment of Taskcluster that will affect this project's use of Taskcluster for CI/CD.

We're splitting Taskcluster for Firefox and Taskcluster for community projects into separate deployments, which unfortunately involves a change for end users like this project.

There are a couple ofsteps:

* changing the Github integration used by this project from Taskcluster to use community-tc-integration
* changing the provisionerId and workerType in your taskcluster.yml, and changing the taskcluster root url where it matters - I've done that for you here.

After you swap the Github Integration over, merging that PR should get you in a good state.

Let me know if you have any questions or need guidance!

cc @djmitche